### PR TITLE
Enable correct RPM calculation

### DIFF
--- a/muddersMIMA_firmware/engine_signals.cpp
+++ b/muddersMIMA_firmware/engine_signals.cpp
@@ -34,7 +34,10 @@ uint16_t engineSignals_getLatestRPM(void) { return latestEngineRPM; }
 
 void engineSignals_begin(void)
 {
+	cli();
 	PCMSK0 = (1<<PCINT0); //only pin D8 will generate a pin change interrupt on ISR PCINT0_vect (which supports D8:D13)
+	PCICR |= (1<<PCIE0); //enable pin change interrupts on port B (D8:D13)
+	sei();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/muddersMIMA_firmware/engine_signals.cpp
+++ b/muddersMIMA_firmware/engine_signals.cpp
@@ -20,7 +20,7 @@ ISR(PCINT0_vect)
 
 		uint32_t periodBetweenTicks_us = tachometerTick_now_us - tachometerTick_previous_us;
 
-		latestEngineRPM = ONE_MINUTE_IN_MICROSECONDS / periodBetweenTicks_us;
+		latestEngineRPM = ONE_MINUTE_IN_MICROSECONDS / (periodBetweenTicks_us * 3 / 2);
 
 		tachometerTick_previous_us = tachometerTick_now_us;
 	}

--- a/muddersMIMA_firmware/engine_signals.cpp
+++ b/muddersMIMA_firmware/engine_signals.cpp
@@ -20,7 +20,7 @@ ISR(PCINT0_vect)
 
 		uint32_t periodBetweenTicks_us = tachometerTick_now_us - tachometerTick_previous_us;
 
-		latestEngineRPM = ONE_MINUTE_IN_MICROSECONDS / (periodBetweenTicks_us * 3 / 2);
+		latestEngineRPM = (ONE_MINUTE_IN_MICROSECONDS * NUM_ENGINE_REVOLUTIONS_PER_CYCLE / NUM_TACHOMETER_PULSES_PER_CYCLE) / periodBetweenTicks_us;
 
 		tachometerTick_previous_us = tachometerTick_now_us;
 	}

--- a/muddersMIMA_firmware/engine_signals.h
+++ b/muddersMIMA_firmware/engine_signals.h
@@ -5,6 +5,8 @@
 	#define engine_signals_h
 
 	#define ONE_MINUTE_IN_MICROSECONDS 60E6
+	#define NUM_ENGINE_REVOLUTIONS_PER_CYCLE 2
+	#define NUM_TACHOMETER_PULSES_PER_CYCLE 3
 	
 	void engineSignals_begin(void);
 


### PR DESCRIPTION
The two commits in this PR enable correct RPM calculation, which was not working before.

- fix: rpm: Count QTY3 ignition pulses per QTY2 revolutions
- fix: rpm: Enable pin-change IRQs on port B

Tested-by: Martin Kennedy <hurricos@gmail.com>

### Addenda
I should probably write up a more complete testing procedure so I can document an A/B test.