### PR TITLE
[WIP] feat: mode1: Better blending

### DIFF
--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -54,7 +54,7 @@ void mode_manualControl_new(void)
 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST)  )
 	{
 		//ECM is sending assist, idle, or regen signal...
-		//but we're in manual mode, so use joystick value instead (either previously stored or value right now)
+		//but we're in blended manual mode, so combine its signal cleverly with the joystick (either previously stored or value right now)
 
 		uint16_t joystick_percent = adc_readJoystick_percent();
 
@@ -75,8 +75,14 @@ void mode_manualControl_new(void)
 
 		//use stored joystick value if conditions are right
 		if( (useStoredJoystickValue == YES                ) && //user previously pushed button
-			(joystick_percent > JOYSTICK_NEUTRAL_MIN_PERCENT) && //joystick is neutral
-			(joystick_percent < JOYSTICK_NEUTRAL_MAX_PERCENT)  ) //joystick is neutral
+			( ( (joystick_percent > JOYSTICK_NEUTRAL_MIN_PERCENT) && //joystick is neutral, or
+			    (joystick_percent < JOYSTICK_NEUTRAL_MAX_PERCENT)
+              ) ||
+              ( (joystick_percent < joystick_percent_stored) && //joystick is less than stored value if assist, or
+                (joystick_percent > JOYSTICK_NEUTRAL_MAX_PERCENT)
+              ) ||
+              ( (joystick_percent > joystick_percent_stored) && //joystick is more than stored value if regen
+                (joystick_percent < JOYSTICK_NEUTRAL_MIN_PERCENT) ) ) )
 		{
 			//replace actual joystick position with previously stored value
 			joystick_percent = joystick_percent_stored;

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -87,6 +87,22 @@ void mode_manualControl_new(void)
 			//replace actual joystick position with previously stored value
 			joystick_percent = joystick_percent_stored;
 		}
+
+		uint16_t ecm_cmdpwr_percent = ecm_getCMDPWR_percent();
+
+		//use the ECM-commanded assist if conditions are right
+		if( ( ( (joystick_percent > JOYSTICK_NEUTRAL_MIN_PERCENT) && //joystick is neutral, and not due to a stored neutral, or
+			    (joystick_percent < JOYSTICK_NEUTRAL_MAX_PERCENT)
+              ) ||
+              ( (joystick_percent < ecm_cmdpwr_percent) && //joystick is less than commanded value if assist, or
+                (joystick_percent > JOYSTICK_NEUTRAL_MAX_PERCENT)
+              ) ||
+              ( (joystick_percent > ecm_cmdpwr_percent) && //joystick is more than commanded value if regen
+                (joystick_percent < JOYSTICK_NEUTRAL_MIN_PERCENT) ) ) )
+		{
+			//replace actual joystick position with the ECM's CMDPWR value
+			joystick_percent = ecm_cmdpwr_percent;
+		}
 		
 		//send assist/idle/regen value to MCM
 		if     (joystick_percent < JOYSTICK_MIN_ALLOWED_PERCENT) { mcm_setAllSignals(MAMODE1_STATE_IS_IDLE,   JOYSTICK_NEUTRAL_NOM_PERCENT); } //signal too low


### PR DESCRIPTION
Improve how we blend the stored and current joystick value.

Before this commit, when in mode 1, a stored assist value was
overridden by any joystick use. This means that increasing a joystick
assist value requires us to reduce from stored *down to* manually
requested value, creating a small jerk as power is instantly changed.

Now, combine the joystick and stored value if they are in the same
direction. If a stored value is (absolutely) greater than the current
joystick position, the stored value takes precedence. This allows us
to carefully adjust-up or adjust-down assist without jerking the
drivetrain around.

## Out-of-scope

Blending with OEM ECM values; this PR is an incremental improvement.

## WIP:

- [ ] Fix bug in implementation of "feat: mode1: Use live or stored joystick value, whichever is greater": 

> WIP, because: failed testing: when using this code, pressing the
joystick just past the neutral position range in the assist direction
causes it to override [the stored value] if you're close to the neutral range. I believe
this comes from JOYSTICK_NEUTRAL_{MAX,MIN}_PERCENT not adequately
filtering out cases?