### PR TITLE
Pedal Controlled Proportional Assist

### DIFF
--- a/muddersMIMA_firmware/config.h
+++ b/muddersMIMA_firmware/config.h
@@ -22,17 +22,20 @@
 		//#define MODE0_BEHAVIOR() mode_manualAssistRegen_withAutoStartStop();
 		//#define MODE0_BEHAVIOR() mode_manualAssistRegen_ignoreECM();
 		//#define MODE0_BEHAVIOR() mode_INWORK_PHEV_mudder();
+		//#define MODE0_BEHAVIOR() mode_proportional_auto_assist();
 
 	//...is in the '1' position
 		//#define MODE1_BEHAVIOR() mode_OEM()
 	  	  #define MODE1_BEHAVIOR() mode_manualAssistRegen_withAutoStartStop();
 		//#define MODE1_BEHAVIOR() mode_manualAssistRegen_ignoreECM();
 		//#define MODE1_BEHAVIOR() mode_INWORK_PHEV_mudder();
+		//#define MODE1_BEHAVIOR() mode_proportional_auto_assist();
 
 	//...is in the '2' position
 		//#define MODE2_BEHAVIOR() mode_OEM()
 		//#define MODE2_BEHAVIOR() mode_manualAssistRegen_withAutoStartStop();
 	  	  #define MODE2_BEHAVIOR() mode_manualAssistRegen_ignoreECM();
 		//#define MODE2_BEHAVIOR() mode_INWORK_PHEV_mudder();
+		//#define MODE2_BEHAVIOR() mode_proportional_auto_assist();
 
 #endif

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -227,8 +227,8 @@ void mode_INWORK_PHEV_mudder(void)
 //Provides assist by adding demand on top of the OEM IMA strategy
 //Uses the OEM regen strategy
 //Fully automatic operation (No joystick required)
+//Need to disable this mode below 15%SOC once SPI communication to LIBCM exists.
 
-void mode_proportional_auto_assist(void)
 void mode_proportional_auto_assist(void)
 {
 	brakeLights_setControlMode(BRAKE_LIGHT_AUTOMATIC);
@@ -239,11 +239,11 @@ void mode_proportional_auto_assist(void)
 
 	if (latestVehicleMPH > maxmph) {latestVehicleMPH = 1;}  //safeguard
 	
-	if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((ECM_CMDPWR_percent*Assist/100)+(sqrt(latestVehicleMPH)*TPS_percent*Boost/100))); } 		
-	else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(sqrt(latestVehicleMPH)*TPS_percent*Cruise/100))); }
-	else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&
-		(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) { mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent*Coast/100)); }
-	else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, ((ECM_CMDPWR_percent*Coast/100)-((latestVehicleMPH*Brake)/100))); }
+	if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (50+(sqrt(latestVehicleMPH)*TPS_percent*Boost/100))); }		
+	else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (50+(sqrt(latestVehicleMPH)*TPS_percent*Cruise/100))); }
+	else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  
+		(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) { mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent*Coast/10)); }
+	else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (50-(sqrt(latestVehicleMPH)*Brake/10))); }
 	else /* (ECM requesting everyting else) */                	{ mcm_passUnmodifiedSignals_fromECM(); } 				
 
 }

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -236,7 +236,7 @@ void mode_proportional_auto_assist(void)
 	uint8_t TPS_percent = adc_getECM_TPS_percent()-tpsoffset; 
 	uint8_t MAP_sensor = adc_getECM_MAP_percent(); 
 	uint16_t latestVehicleRPM = engineSignals_getLatestRPM();
-	uint8_t regen_demand = 50-(sqrt(latestVehicleRPM)*sqrt(latestVehicleMPH)/regenfactor);
+	uint8_t regen_demand = 50-(sqrt(latestVehicleRPM-minrpm)*sqrt(latestVehicleMPH)/regenfactor);
 	uint8_t regen_max = max(10,regen_demand);
 		
 	if (latestVehicleMPH > maxmph) {latestVehicleMPH = 1;}  //safeguard

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -238,8 +238,9 @@ void mode_proportional_auto_assist(void)
 	uint8_t MAP_sensor = adc_getECM_MAP_percent(); 
 	uint16_t latestVehicleRPM = engineSignals_getLatestRPM();
 	uint8_t regen_demand = 50-(sqrt(latestVehicleRPM-minrpm)*sqrt(latestVehicleMPH)/regenfactor);
-	uint8_t regen_max = max(10,regen_demand);
-	uint8_t assist = (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)*sqrt(MAP_sensor)/assistfactor));
+	uint8_t regen = max(10,regen_demand);
+	uint8_t assist_demand = (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)*sqrt(MAP_sensor)/assistfactor));
+	uint8_t assist = min(90,assist_demand);
 
      if      	(assist > previous_assist) { assist = previous_assist + 1; }	//prevents p1440 caused by rapid increase of assist demand
      else if    (assist < previous_assist) { assist = previous_assist - 1; } 	//prevents p1440 caused by rapid decrease of assist demand
@@ -252,7 +253,7 @@ void mode_proportional_auto_assist(void)
 		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  
 				(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) { mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, 50); }
 		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) && 
-		        (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON))	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, regen_max); }
+		        (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON))	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, regen); }
 		else /* (ECM requesting everyting else) */                		{ mcm_passUnmodifiedSignals_fromECM(); } 				
 
 }

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -227,7 +227,6 @@ void mode_INWORK_PHEV_mudder(void)
 //Provides assist by adding demand on top of the OEM IMA strategy
 //Uses the OEM regen strategy
 //Fully automatic operation (No joystick required)
-//Need to disable this mode below 15%SOC once SPI communication to LIBCM exists.
 
 void mode_proportional_auto_assist(void)
 {

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -241,7 +241,8 @@ void mode_proportional_auto_assist(void)
 	uint8_t regen_max = max(10,regen_demand);
 	uint8_t assist = (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)*sqrt(MAP_sensor)/assistfactor));
 
-     if      (assist > previous_assist) { assist = previous_assist + 1; }
+     if      	(assist > previous_assist) { assist = previous_assist + 1; }	//prevents p1440 caused by rapid increase of assist demand
+     else if    (assist < previous_assist) { assist = previous_assist - 1; } 	//prevents p1440 caused by rapid decrease of assist demand
      previous_assist = assist;
 		
 	if (latestVehicleMPH > maxmph) {latestVehicleMPH = 1;}  //safeguard

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -238,11 +238,11 @@ void mode_proportional_auto_assist(void)
 
 	if (latestVehicleMPH > maxmph) {latestVehicleMPH = 1;}  //safeguard
 	
-	if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (50+(sqrt(latestVehicleMPH)*TPS_percent*Boost/100))); }		
-	else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (50+(sqrt(latestVehicleMPH)*TPS_percent*Cruise/100))); }
+	if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)/10*Boost))); }
+	else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)/10*Cruise))); }
 	else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  
-		(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) { mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent*Coast/10)); }
-	else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (50-(sqrt(latestVehicleMPH)*Brake/10))); }
+		(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) { mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)/10*Cruise)-(sqrt(latestVehicleMPH)*Coast/10))); }
+	else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (50-(sqrt(latestVehicleMPH)*Brake/4))); }
 	else /* (ECM requesting everyting else) */                	{ mcm_passUnmodifiedSignals_fromECM(); } 				
 
 }

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -237,18 +237,11 @@ void mode_proportional_auto_assist(void)
 	uint8_t TPS_percent = adc_getECM_TPS_percent()-9; //TPS offset
 	uint8_t latestVehicleRPM = engineSignals_getLatestRPM();
 	
-	uint8_t Assist=.96; 	// light assist is reduced to compensate for increase in power levels due to voltage spoofing.
-	uint8_t Boost=.15; 	// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) 
-	uint8_t Cruise=.35; 	// provides assist during cruise. (circa 6kW highway speeds)
-	uint8_t Coast=1.04; 	// slight reduction in lift-off regen to make smoother (compensates for increase in power levels due to voltage spoofing).
-	uint8_t Brake=.25;  	// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
-				// recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
-
-		if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((Assist*ECM_CMDPWR_percent)+(Boost*sqrt(latestVehicleMPH)*TPS_percent ))); } 		
-		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(Cruise*sqrt(latestVehicleMPH)*TPS_percent ))); }
-		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (Coast*ECM_CMDPWR_percent)); }
-		else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent-(Brake*latestVehicleMPH))); } //TODO: disable this below ~1200rpm
-		else /* (ECM requesting everyting else) */                	{ mcm_passUnmodifiedSignals_fromECM(); } 				
+	if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((Assist*ECM_CMDPWR_percent)+(Boost*sqrt(latestVehicleMPH)*TPS_percent ))); } 		
+	else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(Cruise*sqrt(latestVehicleMPH)*TPS_percent ))); }
+	else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (Coast*ECM_CMDPWR_percent)); }
+	else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent-(Brake*latestVehicleMPH))); } //TODO: disable this below ~1200rpm
+	else /* (ECM requesting everyting else) */                	{ mcm_passUnmodifiedSignals_fromECM(); } 				
 
 }
 

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -229,22 +229,27 @@ void mode_INWORK_PHEV_mudder(void)
 //Fully automatic operation (No joystick required)
 
 void mode_proportional_auto_assist(void)
+void mode_proportional_auto_assist(void)
 {
 	brakeLights_setControlMode(BRAKE_LIGHT_AUTOMATIC);
 	uint8_t ECM_CMDPWR_percent = ecm_getCMDPWR_percent();
 	uint8_t latestVehicleMPH = engineSignals_getLatestVehicleMPH();
 	uint8_t TPS_percent = adc_getECM_TPS_percent()-9; //TPS offset
+	uint8_t latestVehicleRPM = engineSignals_getLatestRPM();
 	
-		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((.96*ECM_CMDPWR_percent)+(.15*sqrt(latestVehicleMPH)*TPS_percent ))); } 		
-			// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) (light assisit is reduced to compensate for increase in power levels due to voltage spoofing).
-		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(.35*sqrt(latestVehicleMPH)*TPS_percent ))); }
-			// provides assist during cruise. (circa 6kW highway speeds)
-		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, ((1.04*ECM_CMDPWR_percent)); }
-			// slight reduction in lift-off regen to make smoother (compensates for increase in power levels due to voltage spoofing).
-		else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent-(.25*latestVehicleMPH))); }
-			// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears.
-		else /* (ECM requesting everyting else) */                		{ mcm_passUnmodifiedSignals_fromECM(); } 				
-		    // recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
+	uint8_t Assist=.96; 	// light assist is reduced to compensate for increase in power levels due to voltage spoofing.
+	uint8_t Boost=.15; 	// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) 
+	uint8_t Cruise=.35; 	// provides assist during cruise. (circa 6kW highway speeds)
+	uint8_t Coast=1.04; 	// slight reduction in lift-off regen to make smoother (compensates for increase in power levels due to voltage spoofing).
+	uint8_t Brake=.25;  	// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
+				// recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
+
+		if 	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((Assist*ECM_CMDPWR_percent)+(Boost*sqrt(latestVehicleMPH)*TPS_percent ))); } 		
+		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(Cruise*sqrt(latestVehicleMPH)*TPS_percent ))); }
+		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (Coast*ECM_CMDPWR_percent)); }
+		else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent-(Brake*latestVehicleMPH))); } //TODO: disable this below ~1200rpm
+		else /* (ECM requesting everyting else) */                	{ mcm_passUnmodifiedSignals_fromECM(); } 				
+
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -234,10 +234,10 @@ void mode_proportional_auto_assist(void)
 	uint8_t ECM_CMDPWR_percent = ecm_getCMDPWR_percent();
 	uint8_t latestVehicleMPH = engineSignals_getLatestVehicleMPH();
 	uint8_t TPS_percent = adc_getECM_TPS_percent()-9; //TPS offset
-
-		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((.96*ECM_CMDPWR_percent)+(.02*latestVehicleMPH*TPS_percent ))); } 		
+	
+		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((.96*ECM_CMDPWR_percent)+(.15*sqrt(latestVehicleMPH)*TPS_percent ))); } 		
 			// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) (light assisit is reduced to compensate for increase in power levels due to voltage spoofing).
-		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(.045*latestVehicleMPH*TPS_percent ))); }
+		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(.35*sqrt(latestVehicleMPH)*TPS_percent ))); }
 			// provides assist during cruise. (circa 6kW highway speeds)
 		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, ((1.04*ECM_CMDPWR_percent)); }
 			// slight reduction in lift-off regen to make smoother (compensates for increase in power levels due to voltage spoofing).

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -235,11 +235,11 @@ void mode_proportional_auto_assist(void)
 	uint8_t latestVehicleMPH = engineSignals_getLatestVehicleMPH();
 	uint8_t TPS_percent = adc_getECM_TPS_percent()-9; //TPS offset
 
-		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(.02*latestVehicleMPH*TPS_percent ))); } 		
-			// circa 10kW assist under gentle acceleration (full assist with larger throttle openings)
+		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, ((.96*ECM_CMDPWR_percent)+(.02*latestVehicleMPH*TPS_percent ))); } 		
+			// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) (light assisit is reduced to compensate for increase in power levels due to voltage spoofing).
 		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, (ECM_CMDPWR_percent+(.045*latestVehicleMPH*TPS_percent ))); }
 			// provides assist during cruise. (circa 6kW highway speeds)
-		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent+(.05*latestVehicleMPH))); }
+		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, ((1.04*ECM_CMDPWR_percent)); }
 			// slight reduction in lift-off regen to make smoother (compensates for increase in power levels due to voltage spoofing).
 		else if	(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON)  	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, (ECM_CMDPWR_percent-(.25*latestVehicleMPH))); }
 			// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears.

--- a/muddersMIMA_firmware/operatingModes.cpp
+++ b/muddersMIMA_firmware/operatingModes.cpp
@@ -7,6 +7,7 @@
 uint8_t joystick_percent_stored = JOYSTICK_NEUTRAL_NOM_PERCENT;
 bool useStoredJoystickValue = NO; //JTS2doLater: I'm not convinced this is required
 uint8_t previous_assist = 50;
+uint8_t previous_MAP = 50;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -231,30 +232,37 @@ void mode_INWORK_PHEV_mudder(void)
 
 void mode_proportional_auto_assist(void)
 {
-	brakeLights_setControlMode(BRAKE_LIGHT_AUTOMATIC);
+	brakeLights_setControlMode(BRAKE_LIGHT_MONITOR_ONLY);
 	uint8_t ECM_CMDPWR_percent = ecm_getCMDPWR_percent();
 	uint8_t latestVehicleMPH = engineSignals_getLatestVehicleMPH();
 	uint8_t TPS_percent = adc_getECM_TPS_percent()-tpsoffset; 
 	uint8_t MAP_sensor = adc_getECM_MAP_percent(); 
+	
+	 if      	(MAP_sensor > previous_MAP) { MAP_sensor = previous_MAP + 1; } //prevents p1440 caused by rapid increase of MAP
+     else if    (MAP_sensor < previous_MAP) { MAP_sensor = previous_MAP - 1; } //prevents p1440 caused by rapid decrease of MAP
+	 previous_MAP = MAP_sensor;	
+	
 	uint16_t latestVehicleRPM = engineSignals_getLatestRPM();
 	uint8_t regen_demand = 50-(sqrt(latestVehicleRPM-minrpm)*sqrt(latestVehicleMPH)/regenfactor);
-	uint8_t regen = max(10,regen_demand);
+	uint8_t regen_max = max(10,regen_demand);
 	uint8_t assist_demand = (50+(sqrt(latestVehicleMPH)*sqrt(TPS_percent)*sqrt(MAP_sensor)/assistfactor));
 	uint8_t assist = min(90,assist_demand);
+	uint8_t SOC = spiToLiBCM_getLiBCM_SoC_percent();
 
-     if      	(assist > previous_assist) { assist = previous_assist + 1; }	//prevents p1440 caused by rapid increase of assist demand
-     else if    (assist < previous_assist) { assist = previous_assist - 1; } 	//prevents p1440 caused by rapid decrease of assist demand
-     previous_assist = assist;
-		
+     if      	(assist > previous_assist) { assist = previous_assist + 1; } //prevents p1440 caused by rapid increase of assist demand
+     else if    (assist < previous_assist) { assist = previous_assist - 1; } //prevents p1440 caused by rapid decrease of assist demand
+	 previous_assist = assist;
+
 	if (latestVehicleMPH > maxmph) {latestVehicleMPH = 1;}  //safeguard
 	
-		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST) 	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, assist); }
+		if 		(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST)    { mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, assist); }
+		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_ASSIST)    { mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, 50); }
 		else if	(ecm_getMAMODE1_state() == MAMODE1_STATE_IS_IDLE)   	{ mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, assist); }
 		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) &&  
 				(gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_OFF)) { mcm_setAllSignals(MAMODE1_STATE_IS_ASSIST, 50); }
 		else if	((ecm_getMAMODE1_state() == MAMODE1_STATE_IS_REGEN) && 
-		        (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON))	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, regen); }
-		else /* (ECM requesting everyting else) */                		{ mcm_passUnmodifiedSignals_fromECM(); } 				
+		        (gpio_getBrakePosition_bool() == BRAKE_LIGHTS_ARE_ON))	{ mcm_setAllSignals(MAMODE1_STATE_IS_REGEN, regen_max); }
+		else /* (ECM requesting everyting else) */                		{ mcm_passUnmodifiedSignals_fromECM(); } 			
 
 }
 

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -4,14 +4,13 @@
 #ifndef modes_h
 	#define modes_h
 	
-	#define  Assist 96 	// light assist is reduced to compensate for increase in power levels due to voltage spoofing.
-	#define  Boost 	16  	// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) 
-	#define  Cruise 36 	// provides assist during cruise. (circa 6kW highway speeds)
-	#define  Coast 	110  	// reduction in lift-off regen to compensates for increase in power levels due to voltage spoofing.
-	#define  Brake 	30   	// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
+	#define  Boost 	35  	// must be > Cruise
+	#define  Cruise 25 	// provides assist during cruise. 
+	#define  Coast 	12  	// compensates for voltage spoofing, must be >10
+	#define  Brake 	37   	// replaces OEM brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
 	#define	 tpsoffset 9 	// throttle position offset at zero
 	#define	 maxmph 112	// maximum MPH safeguard
-				 // recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
+				// LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING) does not need to be defined since this mode does not allow background regen.
 	void operatingModes_handler(void);
 
 #endif

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -8,6 +8,7 @@
 	#define	 maxmph 112	// maximum MPH safeguard
 	#define  regenfactor 10	// regen power level
 	#define  assistfactor 5	// assist power level
+	#define  minrpm 250  // reduces effect of regen at low engine speed.
 
 	void operatingModes_handler(void);
 

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -4,13 +4,13 @@
 #ifndef modes_h
 	#define modes_h
 	
-	#define  Boost 	35  	// must be > Cruise
-	#define  Cruise 25 	// provides assist during cruise. 
-	#define  Coast 	12  	// compensates for voltage spoofing, must be >10
-	#define  Brake 	37   	// replaces OEM brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
+	#define  Cruise 10 	// default=10 provides assist during cruise. 
+	#define  Boost 	12 	// must be > or = Cruise
+	#define  Coast 	12   	// off-throttle regen, level reduced to offset increase in power with increased voltage
+	#define  Brake 	15   	// replicates OEM brake regen buts masks 3rd gear glitch to provide full regen under braking in all gears
 	#define	 tpsoffset 9 	// throttle position offset at zero
-	#define	 maxmph 112	// maximum MPH safeguard
-				// LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING) does not need to be defined since this mode does not allow background regen.
+	#define	 maxmph 112 	// maximum MPH safeguard
+				 // LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING) does not need to be defined since this mode does not allow background regen.
 	void operatingModes_handler(void);
 
 #endif

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -6,8 +6,8 @@
 	
 	#define	 tpsoffset 9 	// throttle position offset at zero
 	#define	 maxmph 112	// maximum MPH safeguard
-	#define  regenfactor 10	// regen power level
-	#define  assistfactor 5	// assist power level
+	#define  regenfactor 11	// regen power level (inverse)
+	#define  assistfactor 5	// assist power level (inverse)
 	#define  minrpm 250  // reduces effect of regen at low engine speed.
 
 	void operatingModes_handler(void);

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -4,13 +4,11 @@
 #ifndef modes_h
 	#define modes_h
 	
-	#define  Cruise 10 	// default=10 provides assist during cruise. 
-	#define  Boost 	12 	// must be > or = Cruise
-	#define  Coast 	12   	// off-throttle regen, level reduced to offset increase in power with increased voltage
-	#define  Brake 	15   	// replicates OEM brake regen buts masks 3rd gear glitch to provide full regen under braking in all gears
 	#define	 tpsoffset 9 	// throttle position offset at zero
-	#define	 maxmph 112 	// maximum MPH safeguard
-				 // LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING) does not need to be defined since this mode does not allow background regen.
+	#define	 maxmph 112	// maximum MPH safeguard
+	#define  regenfactor 10	// regen power level
+	#define  assistfactor 5	// assist power level
+
 	void operatingModes_handler(void);
 
 #endif

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -3,7 +3,13 @@
 
 #ifndef modes_h
 	#define modes_h
-
+	
+	#define  Assist 96 	// light assist is reduced to compensate for increase in power levels due to voltage spoofing.
+	#define  Boost 	17 	// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) 
+	#define  Cruise 38 	// provides assist during cruise. (circa 6kW highway speeds)
+	#define  Coast 	110 	// reduction in lift-off regen to compensates for increase in power levels due to voltage spoofing.
+	#define  Brake 	25  	// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
+				// recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
 	void operatingModes_handler(void);
 
 #endif

--- a/muddersMIMA_firmware/operatingModes.h
+++ b/muddersMIMA_firmware/operatingModes.h
@@ -5,11 +5,13 @@
 	#define modes_h
 	
 	#define  Assist 96 	// light assist is reduced to compensate for increase in power levels due to voltage spoofing.
-	#define  Boost 	17 	// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) 
-	#define  Cruise 38 	// provides assist during cruise. (circa 6kW highway speeds)
-	#define  Coast 	110 	// reduction in lift-off regen to compensates for increase in power levels due to voltage spoofing.
-	#define  Brake 	25  	// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
-				// recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
+	#define  Boost 	16  	// circa 10kW assist under gentle acceleration (full assist with larger throttle openings) 
+	#define  Cruise 36 	// provides assist during cruise. (circa 6kW highway speeds)
+	#define  Coast 	110  	// reduction in lift-off regen to compensates for increase in power levels due to voltage spoofing.
+	#define  Brake 	30   	// increases brake regen to mask 3rd gear glitch & provide full regen under braking in all gears
+	#define	 tpsoffset 9 	// throttle position offset at zero
+	#define	 maxmph 112	// maximum MPH safeguard
+				 // recommended that background regen (part throttle & forced) are be disabled in LIBCM config (REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING)
 	void operatingModes_handler(void);
 
 #endif


### PR DESCRIPTION
//Pedal Controlled Proportional Assist.
//Automatic assist/regen using pedal position and engine signals
//(No joystick required)
//requires power user cable from Licontrol to vehicle ECU signals

**requires @Hurricos PR3 to Measure vehicle speed using pin-change IRQ on VSS**

Configured for:
48S & 60S FoMoCo / zero current hack / VOLTAGE_SPOOFING_LINEAR

Tested on a 2001 manual, consumes 82-15% SOC in ~60miles at approximately 150mpg(imp) / 120 mpg US